### PR TITLE
Use latest 3.8 version number.

### DIFF
--- a/src/spriter2spine.py
+++ b/src/spriter2spine.py
@@ -48,7 +48,7 @@ def gen_spine_obj(name):
                 'width': 0,
                 'height': 0,
                 'hash': ' ',
-                'spine': '3.8.75',
+                'spine': '3.8.99',
                 'fps': 30
             },
             'bones': [],


### PR DESCRIPTION
3.8.99 is the latest (and last) 3.8 version.